### PR TITLE
Correct order of elements within<Metrics>

### DIFF
--- a/mpd/dash-if/HTTPSReporting-Conf-OK-MultiRes.mpd
+++ b/mpd/dash-if/HTTPSReporting-Conf-OK-MultiRes.mpd
@@ -31,8 +31,8 @@
   </AdaptationSet>
  </Period>
   <Metrics metrics="BufferLevel">
-    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
     <Range duration="PT10S"/>
+    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
   </Metrics>
   <!-- SAND Channel -->
   <sand:Channel id="channel-reporting" schemeIdUri="urn:mpeg:dash:sand:channel:http:2016" endpoint="https://sand-http-conf-server.herokuapp.com/metrics"/>


### PR DESCRIPTION
The  [definition of `MetricsType`](https://github.com/MPEGGroup/DASHSchema/blob/993cb92435a68a2752ee036ae78d757633b271bf/DASH-MPD.xsd#L1082) used for the &lt;Metrics&gt; element can include 0 of more &lt;Range&gt; elements followed by &lt;Reporting&gt; elements.

Proposal to fix issue #3 