### PR TITLE
Fix the <Metrics> elements in the sample MPDs 

### DIFF
--- a/mpd/dash-if/HTTPSReporting-Conf-OK-MultiRes.mpd
+++ b/mpd/dash-if/HTTPSReporting-Conf-OK-MultiRes.mpd
@@ -31,8 +31,8 @@
   </AdaptationSet>
  </Period>
   <Metrics metrics="BufferLevel">
-    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
     <Range duration="PT10S"/>
+    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
   </Metrics>
   <!-- SAND Channel -->
   <sand:Channel id="channel-reporting" schemeIdUri="urn:mpeg:dash:sand:channel:http:2016" endpoint="https://sand-http-conf-server.herokuapp.com/metrics"/>

--- a/mpd/dash-if/HTTPSReporting-OK-MultiRes.mpd
+++ b/mpd/dash-if/HTTPSReporting-OK-MultiRes.mpd
@@ -31,8 +31,8 @@
   </AdaptationSet>
  </Period>
   <Metrics metrics="BufferLevel">
-    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
     <Range duration="PT10S"/>
+    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
   </Metrics>
   <!-- SAND Channel -->
   <sand:Channel id="channel-reporting" schemeIdUri="urn:mpeg:dash:sand:channel:http:2016" endpoint="https://sand-http-test-dane.herokuapp.com/metrics"/>

--- a/mpd/dash-if/WSSReporting-Conf-OK-MultiRes.mpd
+++ b/mpd/dash-if/WSSReporting-Conf-OK-MultiRes.mpd
@@ -31,8 +31,8 @@
   </AdaptationSet>
  </Period>
   <Metrics metrics="BufferLevel">
-    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
     <Range duration="PT10S"/>
+    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
   </Metrics>
   <!-- SAND Channel -->
   <sand:Channel id="channel-reporting" schemeIdUri="urn:mpeg:dash:sand:channel:websocket:2016" endpoint="wss://sand-ws-conformance-server.herokuapp.com/"/>

--- a/mpd/dash-if/WSSReporting-OK-MultiRes.mpd
+++ b/mpd/dash-if/WSSReporting-OK-MultiRes.mpd
@@ -31,8 +31,8 @@
   </AdaptationSet>
  </Period>
   <Metrics metrics="BufferLevel">
-    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
     <Range duration="PT10S"/>
+    <Reporting schemeIdUri="urn:mpeg:dash:sand:channel:2016" value="channel-reporting"/>
   </Metrics>
   <!-- SAND Channel -->
   <sand:Channel id="channel-reporting" schemeIdUri="urn:mpeg:dash:sand:channel:websocket:2016" endpoint="wss://sand-ws-test-dane.herokuapp.com"/>


### PR DESCRIPTION
Sample MPDs have 
````
<Metrics>
  <Reporting....
  <Range....
</Metrics>
````

bit according to the MPEG DASH schema, the `<Range>` element comes before the `<Reporting>` element
